### PR TITLE
support single file config

### DIFF
--- a/lib/resque/cluster/version.rb
+++ b/lib/resque/cluster/version.rb
@@ -1,5 +1,5 @@
 module Resque
   class Cluster
-    VERSION = '0.1.2'
+    VERSION = '0.2.0'
   end
 end

--- a/spec/integration/cluster_spec.rb
+++ b/spec/integration/cluster_spec.rb
@@ -7,6 +7,8 @@ BAD_LOCAL_CONFIG = "spec/integration/config/bad_local_config.yml"
 LOCAL_CONFIG2 = "spec/integration/config/local_config2.yml"
 GLOBAL_CONFIG2 = "spec/integration/config/global_config2.yml"
 GLOBAL_REBALANCE_CONFIG2 = "spec/integration/config/global_rebalance_config2.yml"
+GLOBAL_REBALANCE_CONFIG3 = "spec/integration/config/global_rebalance_config3.yml"
+REBALANCE_CONFIG = "spec/integration/config/rebalance_config.yml"
 GLOBAL_CONFIG3 = "spec/integration/config/global_config3.yml"
 GLOBAL_CONFIG4 = "spec/integration/config/global_config4.yml"
 
@@ -137,26 +139,27 @@ RSpec.describe "Resque test-cluster" do
   context "Multiple Configs in the same cluster" do
     before :all do
       @a = TestMemberManager.new(LOCAL_CONFIG, GLOBAL_CONFIG)
-      @b = TestMemberManager.new(LOCAL_CONFIG2, GLOBAL_CONFIG)
-      @c = TestMemberManager.new(LOCAL_CONFIG, GLOBAL_REBALANCE_CONFIG2)
+      @b = TestMemberManager.new(LOCAL_CONFIG2, GLOBAL_CONFIG2)
+      @c = TestMemberManager.new(REBALANCE_CONFIG, GLOBAL_REBALANCE_CONFIG3)
       @a.start
       @b.start
       sleep(3) # rebalance time
     end
 
-    it 'expects to have each cluster member only running workers in it\'s config' do
-      expect(TestMemberManager.counts).to eq({"tar"=>3, "par"=>1, "par,tar,var"=>1})
-      expect(@a.counts).to eq({"tar"=>3, "par"=>1, "par,tar,var"=>1})
-      expect(@b.counts).to be_empty
+    it 'expects to have each cluster member only running workers in its config' do
+      expect(TestMemberManager.counts).to eq('tar' => 3, 'par' => 1, 'par,tar,var' => 1, 'star' => 6)
+      expect(@a.counts).to eq('tar' => 3, 'par' => 1, 'par,tar,var' => 1)
+      expect(@b.counts).to eq('star' => 6)
     end
 
     it 'expects the cluster to redistribute correctly after global config change' do
       @c.start
       sleep(8) # rebalance time
-      expect(TestMemberManager.counts).to eq({"star"=>4})
-      expect(@a.counts).to be_empty
-      expect(@b.counts).to eq({"star"=>4})
-      expect(@c.counts).to be_empty
+      # gru expects maximums to be uniform across the cluster and fails to use all available capacity if they're not
+      expect(TestMemberManager.counts).to eq('par' => 3, 'tar' => 6, 'par,tar,var' => 3, 'star' => 8)
+      expect(@a.counts).to eq('par' => 1, 'tar' => 3, 'par,tar,var' => 1)
+      expect(@b.counts).to eq('star' => 4)
+      expect(@c.counts).to eq('par' => 2, 'tar' => 3, 'par,tar,var' => 2, 'star' => 4)
     end
 
     after :all do

--- a/spec/integration/config/global_rebalance_config3.yml
+++ b/spec/integration/config/global_rebalance_config3.yml
@@ -1,0 +1,6 @@
+rebalance_cluster: true
+global_maximums:
+  par: 4
+  tar: 8
+  "par,tar,var": 4
+  star: 10

--- a/spec/integration/config/global_rebalance_config3.yml
+++ b/spec/integration/config/global_rebalance_config3.yml
@@ -1,6 +1,5 @@
 rebalance_cluster: true
 global_maximums:
   par: 4
-  tar: 8
-  "par,tar,var": 4
-  star: 10
+  tar: 6
+  "par,tar,var": 2

--- a/spec/integration/config/rebalance_config.yml
+++ b/spec/integration/config/rebalance_config.yml
@@ -1,0 +1,4 @@
+par: 4
+tar: 4
+"par,tar,var": 2
+star: 8

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Resque::Cluster::Config do
   let(:redis) { Resque.redis }
 
   before do
+    config.verified?
+
     Resque::Cluster.config = {
       cluster_name: 'unit-test-cluster',
       environment: 'unit-test'
@@ -22,7 +24,6 @@ RSpec.describe Resque::Cluster::Config do
 
   describe 'with a single config file' do
     let(:config) { Resque::Cluster::Config.new(config_path) }
-
     let(:correct_hash) do
       {
         cluster_maximums:         { 'foo' => 2, 'bar' => 50, "foo,bar,baz" => 1 },
@@ -42,71 +43,152 @@ RSpec.describe Resque::Cluster::Config do
       let(:config_path) { support_dir + 'valid_single_old_config.yml' }
 
       it_behaves_like 'a valid config'
+
+      context 'with a missing local maximum' do
+        let(:config) { Resque::Cluster::Config.new(config_path) }
+        let(:config_path) { support_dir + 'single_old_missing_local.yml' }
+
+        it 'should not be verified' do
+          expect(config).not_to be_verified
+        end
+
+        it 'should not be verified' do
+          expect(config.errors).to contain_exactly("Every worker configuration must contain a local and a global maximum.")
+        end
+      end
+
+      context 'with a missing global maximum' do
+        let(:config) { Resque::Cluster::Config.new(config_path) }
+        let(:config_path) { support_dir + 'single_old_missing_global.yml' }
+
+        it 'should not be verified' do
+          expect(config).not_to be_verified
+        end
+
+        it 'should not be verified' do
+          expect(config.errors).to contain_exactly("Every worker configuration must contain a local and a global maximum.")
+        end
+      end
     end
 
     context 'new style' do
       let(:config_path) { support_dir + 'valid_single_new_config.yml' }
 
       it_behaves_like 'a valid config'
+
+      context 'with a missing local maximum' do
+        let(:config) { Resque::Cluster::Config.new(config_path) }
+        let(:config_path) { support_dir + 'missing_local_maximum.yml' }
+
+        it 'should not be verified' do
+          expect(config).not_to be_verified
+        end
+
+        it 'should not be verified' do
+          expect(config.errors).to contain_exactly("Every worker configuration must contain a local and a global maximum.")
+        end
+      end
+
+      context 'with a missing global maximum' do
+        let(:config) { Resque::Cluster::Config.new(config_path) }
+        let(:config_path) { support_dir + 'missing_global_maximum.yml' }
+
+        it 'should not be verified' do
+          expect(config).not_to be_verified
+        end
+
+        it 'should not be verified' do
+          expect(config.errors).to contain_exactly("Every worker configuration must contain a local and a global maximum.")
+        end
+      end
     end
   end
 
-  describe "with valid config files" do
-    let(:local_config_path)  { File.expand_path(File.dirname(__FILE__) + '/../local_config.yml') }
-    let(:global_config_path) { File.expand_path(File.dirname(__FILE__) + '/../global_config.yml') }
-    let(:config)             { Resque::Cluster::Config.new(local_config_path, global_config_path) }
+  describe 'separate config files' do
+    context "with valid config files" do
+      let(:config)             { Resque::Cluster::Config.new(local_config_path, global_config_path) }
+      let(:local_config_path)  { File.expand_path(File.dirname(__FILE__) + '/../local_config.yml') }
+      let(:global_config_path) { File.expand_path(File.dirname(__FILE__) + '/../global_config.yml') }
 
-    let(:correct_hash) do
-      {
-        cluster_maximums:         { 'foo' => 2, 'bar' => 50, "foo,bar,baz" => 1 },
-        host_maximums:            { 'foo' => 1, 'bar' => 9, "foo,bar,baz" => 1 },
-        client_settings:          redis.client.options,
-        rebalance_flag:           false,
-        presume_host_dead_after:  120,
-        max_workers_per_host:     nil,
-        cluster_name:             "unit-test-cluster",
-        environment_name:         "unit-test",
-        manage_worker_heartbeats: true,
-        version_hash:             `git rev-parse --verify HEAD`.strip
-      }
+      let(:correct_hash) do
+        {
+          cluster_maximums:         { 'foo' => 2, 'bar' => 50, "foo,bar,baz" => 1 },
+          host_maximums:            { 'foo' => 1, 'bar' => 9, "foo,bar,baz" => 1 },
+          client_settings:          redis.client.options,
+          rebalance_flag:           false,
+          presume_host_dead_after:  120,
+          max_workers_per_host:     nil,
+          cluster_name:             "unit-test-cluster",
+          environment_name:         "unit-test",
+          manage_worker_heartbeats: true,
+          version_hash:             `git rev-parse --verify HEAD`.strip
+        }
+      end
+
+      it_behaves_like 'a valid config'
+
+      it "config should have no warnings or errors" do
+        expect(config.errors.count).to eql(0)
+        expect(config.warnings.count).to eql(0)
+      end
+
+      it "git_version_hash should be set" do
+        expect(config.version_git_hash).to eql(`git rev-parse --verify HEAD`.strip)
+      end
     end
 
-    it_behaves_like 'a valid config'
+    context 'with a missing local maximum' do
+      let(:config)             { Resque::Cluster::Config.new(local_config_path, global_config_path) }
+      let(:local_config_path)  { support_dir + 'separate_missing_local.yml' }
+      let(:global_config_path) { File.expand_path(File.dirname(__FILE__) + '/../global_config.yml') }
 
-    it "config should have no warnings or errors" do
-      expect(config.errors.count).to eql(0)
-      expect(config.warnings.count).to eql(0)
+      it 'should not be verified' do
+        expect(config).not_to be_verified
+      end
+
+      it 'should not be verified' do
+        expect(config.errors).to contain_exactly("Every worker configuration must contain a local and a global maximum.")
+      end
     end
 
-    it "git_version_hash should be set" do
-      expect(config.version_git_hash).to eql(`git rev-parse --verify HEAD`.strip)
+    context 'with a missing global maximum' do
+      let(:config)             { Resque::Cluster::Config.new(local_config_path, global_config_path) }
+      let(:local_config_path)  { File.expand_path(File.dirname(__FILE__) + '/../local_config.yml') }
+      let(:global_config_path) { support_dir + 'separate_missing_global.yml' }
+
+      it 'should not be verified' do
+        expect(config).not_to be_verified
+      end
+
+      it 'should not be verified' do
+        expect(config.errors).to contain_exactly("Every worker configuration must contain a local and a global maximum.")
+      end
+    end
+
+    context "with invalid config file" do
+      let(:local_config_path)  { File.expand_path(File.dirname(__FILE__) + '/../local_configuration.yml') }
+      let(:global_config_path) { File.expand_path(File.dirname(__FILE__) + '/../../README.rdoc') }
+      let(:config)             { Resque::Cluster::Config.new(local_config_path, global_config_path) }
+      let(:correct_hash)       { {} }
+
+      it "should not be verified" do
+        expect(config.verified?).to eql(false)
+      end
+
+      it "config should have no warnings but 2 errors" do
+        expect(config.errors.count).to eql(1)
+        expect(config.warnings.count).to eql(0)
+        expect(config.errors).to contain_exactly(
+          "#{local_config_path}: Configuration file doesn't exist")
+      end
+
+      it "gru_format should return a an empty hash" do
+        expect(config.gru_format).to eql(correct_hash)
+      end
+
+      it "git_version_hash should not be set" do
+        expect(config.version_git_hash).to be_nil
+      end
     end
   end
-
-  describe "with invalid config file" do
-    let(:local_config_path)  { File.expand_path(File.dirname(__FILE__) + '/../local_configuration.yml') }
-    let(:global_config_path) { File.expand_path(File.dirname(__FILE__) + '/../../README.rdoc') }
-    let(:config)             { Resque::Cluster::Config.new(local_config_path, global_config_path) }
-    let(:correct_hash)       { {} }
-
-    it "should not be verified" do
-      expect(config.verified?).to eql(false)
-    end
-
-    it "config should have no warnings but 2 errors" do
-      expect(config.errors.count).to eql(1)
-      expect(config.warnings.count).to eql(0)
-      expect(config.errors).to contain_exactly(
-        "#{local_config_path}: Configuration file doesn't exist")
-    end
-
-    it "gru_format should return a an empty hash" do
-      expect(config.gru_format).to eql(correct_hash)
-    end
-
-    it "git_version_hash should not be set" do
-      expect(config.version_git_hash).to be_nil
-    end
-  end
-
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -10,6 +10,47 @@ RSpec.describe Resque::Cluster::Config do
     }
   end
 
+  shared_examples_for 'a valid config' do
+    it 'is verified' do
+      expect(config).to be_verified
+    end
+
+    it "gru_format should return a correct hash" do
+      expect(config.gru_format).to eql(correct_hash)
+    end
+  end
+
+  describe 'with a single config file' do
+    let(:config) { Resque::Cluster::Config.new(config_path) }
+
+    let(:correct_hash) do
+      {
+        cluster_maximums:         { 'foo' => 2, 'bar' => 50, "foo,bar,baz" => 1 },
+        host_maximums:            { 'foo' => 1, 'bar' => 9, "foo,bar,baz" => 1 },
+        client_settings:          redis.client.options,
+        rebalance_flag:           true,
+        presume_host_dead_after:  60,
+        max_workers_per_host:     10,
+        cluster_name:             "unit-test-cluster",
+        environment_name:         "unit-test",
+        manage_worker_heartbeats: true,
+        version_hash:             `git rev-parse --verify HEAD`.strip
+      }
+    end
+
+    context 'old style' do
+      let(:config_path) { support_dir + 'valid_single_old_config.yml' }
+
+      it_behaves_like 'a valid config'
+    end
+
+    context 'new style' do
+      let(:config_path) { support_dir + 'valid_single_new_config.yml' }
+
+      it_behaves_like 'a valid config'
+    end
+  end
+
   describe "with valid config files" do
     let(:local_config_path)  { File.expand_path(File.dirname(__FILE__) + '/../local_config.yml') }
     let(:global_config_path) { File.expand_path(File.dirname(__FILE__) + '/../global_config.yml') }
@@ -30,17 +71,11 @@ RSpec.describe Resque::Cluster::Config do
       }
     end
 
-    it "should be verified" do
-      expect(config.verified?).to eql(true)
-    end
+    it_behaves_like 'a valid config'
 
     it "config should have no warnings or errors" do
       expect(config.errors.count).to eql(0)
       expect(config.warnings.count).to eql(0)
-    end
-
-    it "gru_format should return a correct hash" do
-      expect(config.gru_format).to eql(correct_hash)
     end
 
     it "git_version_hash should be set" do

--- a/spec/unit/support/missing_global_maximum.yml
+++ b/spec/unit/support/missing_global_maximum.yml
@@ -1,0 +1,3 @@
+workers:
+  foo:
+    local: 1

--- a/spec/unit/support/missing_local_maximum.yml
+++ b/spec/unit/support/missing_local_maximum.yml
@@ -1,0 +1,3 @@
+workers:
+  foo:
+    global: 1

--- a/spec/unit/support/separate_missing_global.yml
+++ b/spec/unit/support/separate_missing_global.yml
@@ -1,0 +1,2 @@
+bar: 50
+"foo,bar,baz": 1

--- a/spec/unit/support/separate_missing_local.yml
+++ b/spec/unit/support/separate_missing_local.yml
@@ -1,0 +1,2 @@
+bar: 9
+"foo,bar,baz": 1

--- a/spec/unit/support/single_old_missing_global.yml
+++ b/spec/unit/support/single_old_missing_global.yml
@@ -1,0 +1,9 @@
+foo: 1
+bar: 9
+"foo,bar,baz": 1
+rebalance_cluster: true
+max_workers_per_host: 10
+presume_dead_after: 60
+global_maximums:
+  bar: 50
+  "foo,bar,baz": 1

--- a/spec/unit/support/single_old_missing_local.yml
+++ b/spec/unit/support/single_old_missing_local.yml
@@ -1,0 +1,9 @@
+bar: 9
+"foo,bar,baz": 1
+rebalance_cluster: true
+max_workers_per_host: 10
+presume_dead_after: 60
+global_maximums:
+  foo: 2
+  bar: 50
+  "foo,bar,baz": 1

--- a/spec/unit/support/valid_config.yml
+++ b/spec/unit/support/valid_config.yml
@@ -1,0 +1,13 @@
+rebalance_cluster: true
+max_workers_per_host: 10
+presume_dead_after: 60
+workers:
+  foo:
+    local: 1
+    global: 2
+  bar:
+    local: 9
+    global: 50
+  "foo,bar,baz":
+    local: 1
+    global: 1

--- a/spec/unit/support/valid_single_new_config.yml
+++ b/spec/unit/support/valid_single_new_config.yml
@@ -1,0 +1,13 @@
+rebalance_cluster: true
+max_workers_per_host: 10
+presume_dead_after: 60
+workers:
+  foo:
+    local: 1
+    global: 2
+  bar:
+    local: 9
+    global: 50
+  "foo,bar,baz":
+    local: 1
+    global: 1

--- a/spec/unit/support/valid_single_old_config.yml
+++ b/spec/unit/support/valid_single_old_config.yml
@@ -1,0 +1,10 @@
+foo: 1
+bar: 9
+"foo,bar,baz": 1
+rebalance_cluster: true
+max_workers_per_host: 10
+presume_dead_after: 60
+global_maximums:
+  foo: 2
+  bar: 50
+  "foo,bar,baz": 1


### PR DESCRIPTION
There are now 3 ways to configure resque-cluster:

1) The old way with local and global config files.
```yaml
# local.yml
foo: 1
bar: 9
"foo,bar,baz": 1
```
```yaml
# global.yml
rebalance_cluster: true
max_workers_per_host: 10
presume_dead_after: 60
global_maximums:
  foo: 2
  bar: 50
  "foo,bar,baz": 1
```
2) Local and global essentially concatenated into a single file. (Because we sort of supported this before.)
```yaml
# config.yml
foo: 1
bar: 9
"foo,bar,baz": 1
rebalance_cluster: true
max_workers_per_host: 10
presume_dead_after: 60
global_maximums:
  foo: 2
  bar: 50
  "foo,bar,baz": 1
```
3) New style single config.
```yaml
# config.yml
rebalance_cluster: true
max_workers_per_host: 10
presume_dead_after: 60
workers:
  foo:
    local: 1
    global: 2
  bar:
    local: 9
    global: 50
  "foo,bar,baz":
    local: 1
    global: 1
```
1 and 2 will be removed in a subsequent release.