### PR TITLE
Compare host and cluster maximum keys with Sets

### DIFF
--- a/lib/resque/cluster/config.rb
+++ b/lib/resque/cluster/config.rb
@@ -73,10 +73,10 @@ module Resque
       private
 
       def complete_worker_config?
-        host = host_maximums.delete_if { |_, v| v.nil? }
-        cluster = cluster_maximums.delete_if { |_, v| v.nil? }
+        host_keys    = Set.new(host_maximums.delete_if { |_, v| v.nil? }.keys)
+        cluster_keys = Set.new(cluster_maximums.delete_if { |_, v| v.nil? }.keys)
 
-        (host.keys == cluster.keys).tap do |complete|
+        (host_keys == cluster_keys).tap do |complete|
           @errors << "Every worker configuration must contain a local and a global maximum." unless complete
         end
       end

--- a/lib/resque/cluster/version.rb
+++ b/lib/resque/cluster/version.rb
@@ -1,5 +1,5 @@
 module Resque
   class Cluster
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
This never failed in tests, but when trying to use it with a real world config it did fail even though the arrays of keys were the same as far as I could tell. Shoving them into sets before comparing does work, though.